### PR TITLE
Fix active product count in product screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "retail-management-system",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node test/utils.test.js"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@
  * Colonnes: id, created_at, nom, prix_ttc, tva, actif, stock
  */
 import { sb } from "./supabaseClient.js";
+import { countActive } from "./utils.js";
 
 // Elements UI
 const els = {
@@ -37,7 +38,7 @@ async function loadProduits() {
   }
 
   setStatus("Connexion OK");
-  els.nb.textContent = data.length;
+  els.nb.textContent = countActive(data);
   els.total.textContent = data.reduce((acc, p) => acc + (p.stock || 0), 0);
 
   els.list.innerHTML = data.map(p =>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,3 @@
+export function countActive(produits) {
+  return produits.filter(p => p.actif).length;
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,7 @@
+import assert from 'node:assert';
+import { countActive } from '../src/utils.js';
+
+assert.strictEqual(countActive([{actif:true}, {actif:false}, {actif:true}]), 2);
+assert.strictEqual(countActive([]), 0);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- count only active products using new `countActive` helper
- add unit test and package.json to run tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5337cc5c832f9572fa0342efcc0a