### PR TITLE
Add simple tabbed navigation for Stocks, Caisse and Journal sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,36 +17,59 @@
 <body>
   <h1>Mini POS — Test Produits</h1>
 
-  <div class="card">
-    <div>Produits actifs : <span id="nbProduits">--</span></div>
-    <div>Stock total : <span id="stockTotal">--</span></div>
+  <nav>
+    <button id="btn-stocks">Stocks</button>
+    <button id="btn-caisse">Caisse</button>
+    <button id="btn-journal">Journal</button>
+  </nav>
+
+  <div id="tab-stocks">
+    <div class="card">
+      <div>Produits actifs : <span id="nbProduits">--</span></div>
+      <div>Stock total : <span id="stockTotal">--</span></div>
+    </div>
+
+    <div class="card">
+      <h2>Produits</h2>
+      <button id="btnRefresh">Rafraîchir</button>
+      <ul id="listeProduits"></ul>
+      <p id="status" class="muted"></p>
+    </div>
+
+    <div class="card">
+      <h2>Ajouter un produit</h2>
+      <input type="text" id="nom" placeholder="Nom du produit" />
+      <input type="number" id="prix" placeholder="Prix TTC (€)" />
+      <input type="number" id="stock" placeholder="Stock initial" />
+      <select id="actif">
+        <option value="true">Actif</option>
+        <option value="false">Inactif</option>
+      </select>
+      <button id="btnAdd">Ajouter</button>
+    </div>
   </div>
 
-  <div class="card">
-    <h2>Produits</h2>
-    <button id="btnRefresh">Rafraîchir</button>
-    <ul id="listeProduits"></ul>
-    <p id="status" class="muted"></p>
+  <div id="tab-caisse" style="display:none;">
+    <div class="card">
+      <h2>Caisse</h2>
+      <p class="muted">Section caisse à venir...</p>
+    </div>
   </div>
 
-  <div class="card">
-    <h2>Ajouter un produit</h2>
-    <input type="text" id="nom" placeholder="Nom du produit" />
-    <input type="number" id="prix" placeholder="Prix TTC (€)" />
-    <input type="number" id="stock" placeholder="Stock initial" />
-    <select id="actif">
-      <option value="true">Actif</option>
-      <option value="false">Inactif</option>
-    </select>
-    <button id="btnAdd">Ajouter</button>
+  <div id="tab-journal" style="display:none;">
+    <div class="card">
+      <h2>Journal</h2>
+      <p class="muted">Section journal à venir...</p>
+    </div>
   </div>
 
   <!-- Supabase (CDN) -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 
   <!-- Nos modules -->
-  <script type="module" src="./src/config.js"></script>
-  <script type="module" src="./src/supabaseClient.js"></script>
-  <script type="module" src="./src/app.js"></script>
-</body>
+    <script type="module" src="./src/config.js"></script>
+    <script type="module" src="./src/supabaseClient.js"></script>
+    <script type="module" src="./src/app.js"></script>
+    <script type="module" src="./src/tabs.js"></script>
+  </body>
 </html>

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -1,0 +1,20 @@
+const tabStocks = document.getElementById('tab-stocks');
+const tabCaisse = document.getElementById('tab-caisse');
+const tabJournal = document.getElementById('tab-journal');
+
+const btnStocks = document.getElementById('btn-stocks');
+const btnCaisse = document.getElementById('btn-caisse');
+const btnJournal = document.getElementById('btn-journal');
+
+function showTab(tab) {
+  [tabStocks, tabCaisse, tabJournal].forEach(t => {
+    t.style.display = t === tab ? 'block' : 'none';
+  });
+}
+
+btnStocks.addEventListener('click', () => showTab(tabStocks));
+btnCaisse.addEventListener('click', () => showTab(tabCaisse));
+btnJournal.addEventListener('click', () => showTab(tabJournal));
+
+// Afficher par défaut l'onglet Stocks
+showTab(tabStocks);


### PR DESCRIPTION
## Summary
- Wrap existing product UI in `tab-stocks` and add navigation buttons for Stocks, Caisse and Journal tabs
- Include placeholder containers for Caisse and Journal sections with dark-theme styling
- Add `tabs.js` to toggle tab visibility and default to Stocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac02a60c90832f8c29a8c91cf8b64a