### PR TITLE
feat: add caisse tab with sales processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,14 @@
     <div>Stock total : <span id="stockTotal">--</span></div>
   </div>
 
+  <div class="card" id="tab-caisse">
+    <h2>Caisse</h2>
+    <select id="caisseProduit"></select>
+    <input type="number" id="caisseQuantite" placeholder="Quantité" min="1" value="1" />
+    <button id="btnEncaisser">Encaisser</button>
+    <p id="caisseStatus" class="muted"></p>
+  </div>
+
   <div class="card">
     <h2>Produits</h2>
     <button id="btnRefresh">Rafraîchir</button>
@@ -48,5 +56,6 @@
   <script type="module" src="./src/config.js"></script>
   <script type="module" src="./src/supabaseClient.js"></script>
   <script type="module" src="./src/app.js"></script>
+  <script type="module" src="./src/caisse.js"></script>
 </body>
 </html>

--- a/src/caisse.js
+++ b/src/caisse.js
@@ -1,0 +1,105 @@
+import { sb } from "./supabaseClient.js";
+
+export async function initCaisseTab() {
+  const els = {
+    select: document.getElementById("caisseProduit"),
+    qty: document.getElementById("caisseQuantite"),
+    btn: document.getElementById("btnEncaisser"),
+    status: document.getElementById("caisseStatus"),
+  };
+
+  async function loadProduits() {
+    els.select.innerHTML = "";
+    const { data, error } = await sb
+      .from("produits")
+      .select("id, nom")
+      .eq("actif", true)
+      .order("nom");
+
+    if (error) {
+      console.error("Erreur chargement produits", error);
+      els.status.textContent = "Erreur: " + error.message;
+      return;
+    }
+
+    els.select.innerHTML = data
+      .map(p => `<option value="${p.id}">${p.nom}</option>`)
+      .join("");
+  }
+
+  async function encaisser() {
+    const produitId = els.select.value;
+    const quantite = parseInt(els.qty.value, 10);
+
+    if (!produitId || isNaN(quantite) || quantite <= 0) {
+      alert("Produit et quantité requis");
+      return;
+    }
+
+    const { data: prod, error: prodErr } = await sb
+      .from("produits")
+      .select("stock, prix_ttc")
+      .eq("id", produitId)
+      .single();
+
+    if (prodErr) {
+      alert("Erreur : " + prodErr.message);
+      return;
+    }
+
+    if ((prod.stock || 0) < quantite) {
+      alert("Stock insuffisant");
+      return;
+    }
+
+    const total = (prod.prix_ttc || 0) * quantite;
+
+    const { data: vente, error: venteErr } = await sb
+      .from("ventes")
+      .insert([{ total_ttc: total }])
+      .select()
+      .single();
+
+    if (venteErr) {
+      alert("Erreur : " + venteErr.message);
+      return;
+    }
+
+    const { error: ligneErr } = await sb
+      .from("ventes_lignes")
+      .insert([
+        {
+          vente_id: vente.id,
+          produit_id: produitId,
+          quantite,
+          prix_ttc: prod.prix_ttc,
+        },
+      ]);
+
+    if (ligneErr) {
+      alert("Erreur : " + ligneErr.message);
+      return;
+    }
+
+    const { error: updErr } = await sb
+      .from("produits")
+      .update({ stock: prod.stock - quantite })
+      .eq("id", produitId);
+
+    if (updErr) {
+      alert("Erreur : " + updErr.message);
+      return;
+    }
+
+    els.qty.value = "1";
+    els.status.textContent = "Vente enregistrée";
+    setTimeout(() => (els.status.textContent = ""), 2000);
+    await loadProduits();
+  }
+
+  els.btn.addEventListener("click", encaisser);
+  loadProduits();
+}
+
+initCaisseTab();
+


### PR DESCRIPTION
## Summary
- add dark themed Caisse tab with product selector, quantity input and payment button
- implement initCaisseTab to populate products, record sales and update stock

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac02b799fc832f8eda80964bdf3dd1