### PR TITLE
feat: add sales journal tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,33 +12,49 @@
     button { padding:8px 12px; margin-top:6px; background:green; color:#fff; border:none; border-radius:4px; cursor:pointer; }
     button:hover { background:darkgreen; }
     .muted { color:#9ca3af; }
+    .tab { display:none; }
+    .tab.active { display:block; }
   </style>
 </head>
 <body>
   <h1>Mini POS — Test Produits</h1>
 
-  <div class="card">
-    <div>Produits actifs : <span id="nbProduits">--</span></div>
-    <div>Stock total : <span id="stockTotal">--</span></div>
+  <nav>
+    <button data-tab="tab-produits">Produits</button>
+    <button data-tab="tab-journal">Journal</button>
+  </nav>
+
+  <div id="tab-produits" class="tab active">
+    <div class="card">
+      <div>Produits actifs : <span id="nbProduits">--</span></div>
+      <div>Stock total : <span id="stockTotal">--</span></div>
+    </div>
+
+    <div class="card">
+      <h2>Produits</h2>
+      <button id="btnRefresh">Rafraîchir</button>
+      <ul id="listeProduits"></ul>
+      <p id="status" class="muted"></p>
+    </div>
+
+    <div class="card">
+      <h2>Ajouter un produit</h2>
+      <input type="text" id="nom" placeholder="Nom du produit" />
+      <input type="number" id="prix" placeholder="Prix TTC (€)" />
+      <input type="number" id="stock" placeholder="Stock initial" />
+      <select id="actif">
+        <option value="true">Actif</option>
+        <option value="false">Inactif</option>
+      </select>
+      <button id="btnAdd">Ajouter</button>
+    </div>
   </div>
 
-  <div class="card">
-    <h2>Produits</h2>
-    <button id="btnRefresh">Rafraîchir</button>
-    <ul id="listeProduits"></ul>
-    <p id="status" class="muted"></p>
-  </div>
-
-  <div class="card">
-    <h2>Ajouter un produit</h2>
-    <input type="text" id="nom" placeholder="Nom du produit" />
-    <input type="number" id="prix" placeholder="Prix TTC (€)" />
-    <input type="number" id="stock" placeholder="Stock initial" />
-    <select id="actif">
-      <option value="true">Actif</option>
-      <option value="false">Inactif</option>
-    </select>
-    <button id="btnAdd">Ajouter</button>
+  <div id="tab-journal" class="tab">
+    <div class="card">
+      <h2>Journal des ventes</h2>
+      <ul id="journalList"></ul>
+    </div>
   </div>
 
   <!-- Supabase (CDN) -->

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@
  */
 import { sb } from "./supabaseClient.js";
 import { countActive } from "./utils.js";
+import { initJournalTab } from "./journal.js";
 
 // Elements UI
 const els = {
@@ -18,6 +19,18 @@ const els = {
   stock: document.getElementById("stock"),
   actif: document.getElementById("actif"),
 };
+
+// gestion des onglets
+const tabs = document.querySelectorAll(".tab");
+const tabButtons = document.querySelectorAll("[data-tab]");
+tabButtons.forEach(btn => {
+  btn.addEventListener("click", () => {
+    tabs.forEach(tab => tab.classList.toggle("active", tab.id === btn.dataset.tab));
+    if (btn.dataset.tab === "tab-journal") {
+      initJournalTab();
+    }
+  });
+});
 
 function setStatus(msg="") { els.status.textContent = msg; }
 

--- a/src/journal.js
+++ b/src/journal.js
@@ -1,0 +1,29 @@
+import { sb } from "./supabaseClient.js";
+
+export async function initJournalTab() {
+  const list = document.getElementById("journalList");
+  if (!list) return;
+
+  list.innerHTML = "<li class='muted'>Chargement...</li>";
+
+  const { data, error } = await sb
+    .from("ventes_lignes")
+    .select("quantite, prix_unitaire_ttc, ventes(created_at), produits(nom)")
+    .order("ventes.created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    console.error("Supabase select error:", error);
+    list.innerHTML = `<li>Erreur : ${error.message}</li>`;
+    return;
+  }
+
+  list.innerHTML = data.map(ligne => {
+    const date = new Date(ligne.ventes.created_at).toLocaleString("fr-FR");
+    const nom = ligne.produits.nom;
+    const qte = ligne.quantite;
+    const prix = ligne.prix_unitaire_ttc;
+    const total = qte * prix;
+    return `<li>${date} — ${nom} — Qté: ${qte} — PU: ${prix.toFixed(2)}€ — Total: ${total.toFixed(2)}€</li>`;
+  }).join("");
+}


### PR DESCRIPTION
## Summary
- add tab-based layout and placeholder list for sales journal
- load recent sales lines via Supabase and render journal entries
- refresh journal data when switching tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac02bd652c832fbcd6b11399de2930