### PR TITLE
Add caisse sale tests with mocked Supabase client

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "node test/utils.test.js"
+    "test": "node test/utils.test.js && node test/caisse.test.js"
   }
 }

--- a/src/caisse.js
+++ b/src/caisse.js
@@ -1,0 +1,52 @@
+/**
+ * Logique de vente simple pour la caisse.
+ * @param {object} sb - client Supabase
+ * @param {string} produitId - identifiant du produit
+ * @param {number} quantite - quantité vendue
+ * @returns {Promise<string>} id de la vente créée
+ */
+export async function sell(sb, produitId, quantite) {
+  const { data: produit, error } = await sb
+    .from('produits')
+    .select('id, stock, prix_ttc')
+    .eq('id', produitId)
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (produit.stock < quantite) {
+    throw new Error('Stock insuffisant');
+  }
+
+  const total_ttc = produit.prix_ttc * quantite;
+  const { data: vente, error: errVente } = await sb
+    .from('ventes')
+    .insert([{ total_ttc }])
+    .select()
+    .single();
+
+  if (errVente) {
+    throw new Error(errVente.message);
+  }
+
+  const { error: errLignes } = await sb
+    .from('ventes_lignes')
+    .insert([{ quantite, total_ttc, vente_id: vente.id, produit_id: produitId }]);
+
+  if (errLignes) {
+    throw new Error(errLignes.message);
+  }
+
+  const { error: errStock } = await sb
+    .from('produits')
+    .update({ stock: produit.stock - quantite })
+    .eq('id', produitId);
+
+  if (errStock) {
+    throw new Error(errStock.message);
+  }
+
+  return vente.id;
+}

--- a/test/caisse.test.js
+++ b/test/caisse.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert';
+import { sell } from '../src/caisse.js';
+
+function createSupabaseMock(initial) {
+  const tables = {
+    produits: initial.produits.map(p => ({ ...p })),
+    ventes: [],
+    ventes_lignes: []
+  };
+  let idCounter = 1;
+  return {
+    tables,
+    from(table) {
+      return {
+        select() {
+          return {
+            eq(column, value) {
+              return {
+                async single() {
+                  const row = tables[table].find(r => r[column] === value);
+                  if (!row) {
+                    return { data: null, error: { message: 'Not found' } };
+                  }
+                  return { data: { ...row }, error: null };
+                }
+              };
+            }
+          };
+        },
+        insert(rows) {
+          const withIds = rows.map(row => ({ id: `${table}_${idCounter++}`, ...row }));
+          tables[table].push(...withIds);
+          return {
+            select() {
+              return {
+                async single() {
+                  return { data: withIds[0], error: null };
+                }
+              };
+            }
+          };
+        },
+        update(values) {
+          return {
+            async eq(column, value) {
+              const row = tables[table].find(r => r[column] === value);
+              if (!row) {
+                return { data: null, error: { message: 'Not found' } };
+              }
+              Object.assign(row, values);
+              return { data: row, error: null };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+(async () => {
+  const sbReject = createSupabaseMock({ produits: [{ id: 'p1', stock: 5, prix_ttc: 10 }] });
+  await assert.rejects(() => sell(sbReject, 'p1', 6), /Stock insuffisant/);
+
+  const sbOk = createSupabaseMock({ produits: [{ id: 'p1', stock: 5, prix_ttc: 10 }] });
+  const venteId = await sell(sbOk, 'p1', 2);
+  assert.strictEqual(sbOk.tables.produits[0].stock, 3);
+  assert.strictEqual(sbOk.tables.ventes.length, 1);
+  assert.strictEqual(sbOk.tables.ventes[0].id, venteId);
+  assert.strictEqual(sbOk.tables.ventes_lignes.length, 1);
+  assert.strictEqual(sbOk.tables.ventes_lignes[0].quantite, 2);
+  assert.strictEqual(sbOk.tables.ventes_lignes[0].vente_id, venteId);
+  assert.strictEqual(sbOk.tables.ventes_lignes[0].produit_id, 'p1');
+
+  console.log('All caisse tests passed.');
+})();


### PR DESCRIPTION
## Summary
- implement simple `sell` function for caisse
- add mocked Supabase tests covering sale success and rejection
- run both test suites via npm test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac02c29d5c832f9080ae1f50caaa5b