### PR TITLE
fix: remove journal table usage in caisse

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@
 - total_ttc (numeric)
 - vente_id (uuid, FK → ventes.id)
 - produit_id (uuid, FK → produits.id)
+
+## Remarques
+- La table `journal` n'existe pas. Le suivi des ventes se fait via les tables `ventes` et `ventes_lignes`.
+- L'onglet Caisse appelle le RPC transactionnel `vente_simple` qui insère la vente, ajoute la ligne correspondante et décrémente `produits.stock`.

--- a/src/caisse.js
+++ b/src/caisse.js
@@ -38,11 +38,8 @@ async function loadProduits() {
 async function vendreProduit(event) {
   if (event.target.tagName !== "BUTTON") return;
   const id = event.target.dataset.id;
-  const prix = parseFloat(event.target.dataset.prix);
 
-  const { error } = await sb
-    .from("journal")
-    .insert([{ produit_id: id, montant: prix }]);
+  const { error } = await sb.rpc("vente_simple", { produit_id: id });
 
   if (error) {
     alert("Erreur : " + error.message);
@@ -50,6 +47,7 @@ async function vendreProduit(event) {
   }
 
   alert("Vente enregistrée !");
+  loadProduits();
 }
 
 els.refresh.addEventListener("click", loadProduits);


### PR DESCRIPTION
## Summary
- replace journal insert with `vente_simple` RPC to record sales and decrement stock
- document that sales are tracked via `ventes` and `ventes_lignes` with no `journal` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b22046b610832fa5e065ce7708aea2